### PR TITLE
Update website meta for social graph meta tags.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,3 +64,7 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
   category = "categories"
   publication_type = "publication_types"
   author = "authors"
+
+# Website META
+[params]
+  description = "Integrated Data, Energy Analysis + Simulation"


### PR DESCRIPTION
Reference: https://xvrdm.github.io/2017/10/23/socialize-your-blogdown/

There are two families of social graph meta tags used in Hugo-Academic
theme: `twitter:<tag-name>` for Twitter and `og:<tag-name>` for Facebook
Open Graph. It is specified through:
`themes/YOUR_THEME_NAME/layouts/partials/header.html`

* `og:image`: link to the image
* `og:description`: short description text
* `og:url`: actual reference url
* `og:title`: title for the page
* `twitter:card`: type of the card

For `og:description`, it is created in the following way in
Hugo-Academic theme:

1. Use `summary` yaml field in blog page if exists
2. Use `abstract` yaml field in blog page if exists
3. Use `description` toml field under `params` section in `config.toml` if
   exists
4. If none of those exist, use the `role` field for the latest author that
   made changes.

In this pull request, a `description` field under `params` section in
`config.toml` is added.