### PR TITLE
Update website meta for social graph meta tags.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,7 +64,3 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
   category = "categories"
   publication_type = "publication_types"
   author = "authors"
-
-# Website META
-[params]
-  description = "Integrated Data, Energy Analysis + Simulation"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -12,7 +12,7 @@ day_night = true
 font = "default"
 
 # Description for social sharing and search engines. If undefined, superuser role is used in place.
-description = ""
+description = "Integrated Data, Energy Analysis + Simulation"
 
 # Default image for social sharing and search engines. Place image in `static/img/` folder and specify image name here.
 sharing_image = ""


### PR DESCRIPTION
In this pull request, a description used for social sharing of this
website is added in `config/_default/params.toml`.

The former solution did not work because variables defined in
`config/_default` always have the highest priority, which means they
will overwrite any variable defined in `config.toml` that has the same
name.