### PR TITLE
Use lab logo as the default image for social sharing and search engines.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -15,7 +15,7 @@ font = "default"
 description = "Integrated Data, Energy Analysis + Simulation"
 
 # Default image for social sharing and search engines. Place image in `static/img/` folder and specify image name here.
-sharing_image = ""
+sharing_image = "logo.png"
 
 # Twitter username (without @). Used when a vistor shares your site on Twitter.
 twitter = ""


### PR DESCRIPTION
In this pull request, lab logo is used as the default image for social sharing and search engines.

This is achieved by setting `sharing_image` field value to the lab logo path in `config/_default/param.toml`.